### PR TITLE
Sync devel into master: repair CI and pick up accumulated devel work

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: KEGGgraph
 Type: Package
 Title: KEGGgraph: A graph approach to KEGG PATHWAY in R and
         Bioconductor
-Version: 1.65.0
+Version: 1.66.0
 Date: 2022-12-18
 Author: Jitao David Zhang, with inputs from Paul Shannon and Hervé Pagès
 Maintainer: Jitao David Zhang <jitao_david.zhang@roche.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: KEGGgraph
 Type: Package
 Title: KEGGgraph: A graph approach to KEGG PATHWAY in R and
         Bioconductor
-Version: 1.60.0
+Version: 1.61.0
 Date: 2022-12-18
 Author: Jitao David Zhang, with inputs from Paul Shannon and Hervé Pagès
 Maintainer: Jitao David Zhang <jitao_david.zhang@roche.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: KEGGgraph
 Type: Package
 Title: KEGGgraph: A graph approach to KEGG PATHWAY in R and
         Bioconductor
-Version: 1.62.0
+Version: 1.63.0
 Date: 2022-12-18
 Author: Jitao David Zhang, with inputs from Paul Shannon and Hervé Pagès
 Maintainer: Jitao David Zhang <jitao_david.zhang@roche.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: KEGGgraph
 Type: Package
 Title: KEGGgraph: A graph approach to KEGG PATHWAY in R and
         Bioconductor
-Version: 1.61.0
+Version: 1.62.0
 Date: 2022-12-18
 Author: Jitao David Zhang, with inputs from Paul Shannon and Hervé Pagès
 Maintainer: Jitao David Zhang <jitao_david.zhang@roche.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: KEGGgraph
 Type: Package
 Title: KEGGgraph: A graph approach to KEGG PATHWAY in R and
         Bioconductor
-Version: 1.66.0
+Version: 1.67.0
 Date: 2022-12-18
 Author: Jitao David Zhang, with inputs from Paul Shannon and Hervé Pagès
 Maintainer: Jitao David Zhang <jitao_david.zhang@roche.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: KEGGgraph
 Type: Package
 Title: KEGGgraph: A graph approach to KEGG PATHWAY in R and
         Bioconductor
-Version: 1.63.0
+Version: 1.64.0
 Date: 2022-12-18
 Author: Jitao David Zhang, with inputs from Paul Shannon and Hervé Pagès
 Maintainer: Jitao David Zhang <jitao_david.zhang@roche.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: KEGGgraph
 Type: Package
 Title: KEGGgraph: A graph approach to KEGG PATHWAY in R and
         Bioconductor
-Version: 1.59.3
+Version: 1.60.0
 Date: 2022-12-18
 Author: Jitao David Zhang, with inputs from Paul Shannon and Hervé Pagès
 Maintainer: Jitao David Zhang <jitao_david.zhang@roche.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: KEGGgraph
 Type: Package
 Title: KEGGgraph: A graph approach to KEGG PATHWAY in R and
         Bioconductor
-Version: 1.64.0
+Version: 1.65.0
 Date: 2022-12-18
 Author: Jitao David Zhang, with inputs from Paul Shannon and Hervé Pagès
 Maintainer: Jitao David Zhang <jitao_david.zhang@roche.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Package: KEGGgraph
 Type: Package
 Title: KEGGgraph: A graph approach to KEGG PATHWAY in R and
         Bioconductor
-Version: 1.67.0
-Date: 2022-12-18
+Version: 1.67.1
+Date: 2025-04-14
 Author: Jitao David Zhang, with inputs from Paul Shannon and Hervé Pagès
 Maintainer: Jitao David Zhang <jitao_david.zhang@roche.com>
 Description: KEGGGraph is an interface between KEGG pathway and graph
@@ -21,6 +21,6 @@ Suggests: RBGL, testthat, RColorBrewer, org.Hs.eg.db,
         hgu133plus2.db, SPIA
 Collate: kegg2graph-functions.R parse.R annotation.R graph.R kgmlfile.R
         misc.R vis.R
-URL: http://www.nextbiomotif.com
+URL: https://accio.github.io/research/#software
 biocViews: Pathways, GraphAndNetwork, Visualization, KEGG
 Encoding: UTF-8

--- a/man/getRgraphvizEdgeNames.Rd
+++ b/man/getRgraphvizEdgeNames.Rd
@@ -17,7 +17,7 @@ getRgraphvizEdgeNames(graph)
   A list of names, the order is determined by the edge order.
 }
 \references{ Rgraphviz package }
-\author{ Jitao David Zhang \url{maito:jitao_david.zhang@roche.com} }
+\author{ Jitao David Zhang \url{mailto:jitao_david.zhang@roche.com} }
 \examples{
 tnodes <- c("Hamburg","Dortmund","Bremen", "Paris")
 tedges <- list("Hamburg"=c("Dortmund", "Bremen"),

--- a/man/parseReaction.Rd
+++ b/man/parseReaction.Rd
@@ -20,5 +20,5 @@ parseReaction(reaction)
   An object of \code{\link{KEGGReaction-class}}
 }
 \references{ KGML Document Manual \url{https://www.genome.jp/kegg/docs/xml/}}
-\author{ Jitao David Zhang \url{mail:jitao_david.zhang@roche.com} }
+\author{ Jitao David Zhang \url{mailto:jitao_david.zhang@roche.com} }
 \keyword{IO}


### PR DESCRIPTION
Brings `master` (v1.59.3, Dec 2022) up to date with `devel` (v1.67.1) and repairs the GitHub Actions workflow so that R CMD check actually runs.

## CI repairs

Before this, **no job had ever completed** in this repository. Three independent breakages:

1. The setup-r step read the R version from `matrix.r-version`, but the matrix declares `matrix.config.r`. The resulting empty string overrode the action's own `release` default, so setup-r enumerated the full R version list from `api.r-hub.io` and died on the ancient `0.50-a1` entry with `TypeError: Invalid Version: 0.50-a1.0`. This killed macOS and both Windows jobs at the *first* step.
2. `ubuntu-20.04` runner images are retired, so all three Ubuntu jobs queued for 24h and were cancelled without executing a single step.
3. `setup-r` was pinned to a SHA from October 2021; `actions/checkout` was v3 (deprecated Node 20).

Also adds `r-lib/actions/setup-pandoc@v2`. R CMD check cannot rebuild `.Rmd` vignettes without pandoc, and no runner provides it where R can find it — this is what currently fails all six jobs on #16.

The Windows `r: '3.6'` job is swapped for `oldrel-1`: it had never got past setup-r, and current Bioconductor dependencies (graph, Rgraphviz, RBGL) no longer build on R 3.6.

## Package changes

Everything already on `devel` and previously unmerged, including the `mailto:` link fixes in `man/getRgraphvizEdgeNames.Rd` and `man/parseReaction.Rd`. Those two typos are the sole reason all six master jobs currently report `Status: 1 WARNING`, which `check-r-package@v2` escalates to a failure via its default `error-on: "warning"`.

## Verification

Local `R CMD check` on this branch: **Status: OK**, with both test scripts passing.

Follow-up, not included here: `vignettes/KEGGgraph.Rnw` has a latent trap where the `orgHuman` chunk is `fig=TRUE` but its only plot sits inside `if(require(org.Hs.eg.db))`. When that Suggests package is absent the chunk emits a zero-page PDF and pdflatex fails with `PDF inclusion: required page does not exist <0>`. It does not fire on CI because Suggests are installed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)